### PR TITLE
Bookkeep network with state entities. Closes #104

### DIFF
--- a/chimerapy/manager.py
+++ b/chimerapy/manager.py
@@ -411,7 +411,7 @@ class Manager:
 
         # Broadcast via a ThreadPool
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=len(self.state.workers)
+            max_workers=len(self.state.workers) + 1
         ) as executor:
 
             def request_start(url):

--- a/chimerapy/manager.py
+++ b/chimerapy/manager.py
@@ -19,7 +19,7 @@ import networkx as nx
 import requests
 
 from chimerapy import config
-from .states import ManagerState, WorkerState, NodeState
+from .states import ManagerState, WorkerState
 from .networking import Server, Client, DataChunk
 from .graph import Graph
 from .exceptions import CommitGraphError
@@ -53,7 +53,9 @@ class Manager:
                 Currently, this is used to configure the ZMQ log handler.
         """
         # Saving input parameters
-        self.state = ManagerState(id="Manager", ip="localhost", port=port)
+        self.state = ManagerState(
+            id="Manager", ip="localhost", port=port
+        )
         self.max_num_of_workers = max_num_of_workers
         self.has_shutdown = False
 
@@ -71,7 +73,6 @@ class Manager:
         os.makedirs(self.logdir, exist_ok=True)
 
         # Instance variables
-        self.workers: Dict[str, Dict[str, Any]] = {}
         self.graph: Graph = Graph()
         self.worker_graph_map: Dict = {}
         self.commitable_graph: bool = False
@@ -101,13 +102,29 @@ class Manager:
         logger.info(f"Manager started at {self.server.host}:{self.server.port}")
 
         # Updating the manager's port to the found available port
-        self.host, self.port = self.server.host, self.server.port
+        self.state.ip, self.state.port = self.server.host, self.server.port
 
     def __repr__(self):
         return f"<Manager @{self.host}:{self.port}>"
 
     def __str__(self):
         return self.__repr__()
+
+    ####################################################################
+    ## Properties
+    ####################################################################
+
+    @property
+    def host(self) -> str:
+        return self.state.ip
+
+    @property
+    def port(self) -> int:
+        return self.state.port
+
+    @property
+    def workers(self) -> Dict[str, WorkerState]:
+        return self.state.workers
 
     ####################################################################
     ## Front-End API
@@ -117,7 +134,7 @@ class Manager:
         return web.json_response(self.state.to_dict())
 
     ####################################################################
-    ## Message Reactivity API
+    ## Worker -> Manager Messages
     ####################################################################
 
     async def register_worker(self, request: web.Request):
@@ -162,62 +179,6 @@ class Manager:
         return web.HTTPOk()
 
     ####################################################################
-    ## Helper Methods (Front-end)
-    ####################################################################
-
-    def dashboard_dict(self) -> Dict:
-
-        # Convert name to id
-        id_to_name = {
-            n: data["object"].name for n, data in self.graph.G.nodes(data=True)
-        }
-
-        # Add default Manager information
-        network_information = {
-            "ip": self.host,
-            "port": self.port,
-        }
-
-        # Then adding per worker information
-        workers_json = []
-        for worker_id, worker_data in self.workers.items():
-            worker_json = {
-                "id": worker_id,
-                "name": worker_data["name"],
-                "ip": worker_data["http_ip"],
-                "port": worker_data["http_port"],
-                "nodes": [],
-            }
-
-            # Then adding per Node information
-            for node_id, node_status in worker_data["nodes_status"].items():
-                if node_id in self.nodes_server_table:
-                    worker_json["nodes"].append(
-                        {
-                            "id": node_id,
-                            "name": id_to_name[node_id],
-                            "ip": self.nodes_server_table[node_id]["host"],
-                            "port": self.nodes_server_table[node_id]["port"],
-                        }
-                    )
-                else:
-                    worker_json["nodes"].append(
-                        {
-                            "id": node_id,
-                            "name": id_to_name[node_id],
-                            "ip": "",
-                            "port": -1,
-                        }
-                    )
-
-            # Appending later
-            workers_json.append(worker_json)
-
-        # Adding it
-        network_information["workers"] = workers_json
-        return network_information
-
-    ####################################################################
     ## Helper Methods (Cluster)
     ####################################################################
 
@@ -236,7 +197,7 @@ class Manager:
 
         # Generate meta record
         meta = {
-            "workers": list(self.workers.keys()),
+            "workers": list(self.state.workers.keys()),
             "nodes": list(self.graph.G.nodes()),
             "worker_graph_map": self.worker_graph_map,
             "nodes_server_table": self.nodes_server_table,
@@ -321,7 +282,8 @@ class Manager:
 
             # Send the request to each worker
             r = requests.get(
-                self.workers[worker_id]["url"] + "/nodes/server_data",
+                f"http://{self.state.workers[worker_id].ip}:{self.state.workers[worker_id].port}"
+                + "/nodes/server_data",
             )
 
             if r.status_code == requests.codes.ok:
@@ -358,7 +320,8 @@ class Manager:
 
             # Send the request to each worker
             r = requests.post(
-                self.workers[worker_id]["url"] + "/nodes/server_data",
+                f"http://{self.state.workers[worker_id].ip}:{self.state.workers[worker_id].port}"
+                + "/nodes/server_data",
                 json.dumps(self.nodes_server_table),
                 timeout=config.get("manager.timeout.info-request"),
             )
@@ -422,7 +385,7 @@ class Manager:
         for worker_id in worker_graph_map:
 
             # First check if the worker is registered!
-            if worker_id not in self.workers:
+            if worker_id not in self.state.workers:
                 logger.error(f"{worker_id} is not register to Manager.")
                 checks.append(False)
                 break
@@ -454,7 +417,7 @@ class Manager:
 
         # Broadcast via a ThreadPool
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=len(self.workers)
+            max_workers=len(self.state.workers)
         ) as executor:
 
             def request_start(url):
@@ -465,8 +428,8 @@ class Manager:
                 return r, url
 
             futures = (
-                executor.submit(request_start, worker["url"])
-                for worker in self.workers.values()
+                executor.submit(request_start, f"http://{worker.ip}:{worker.port}")
+                for worker in self.state.workers.values()
             )
             success = []
             for future in concurrent.futures.as_completed(futures):
@@ -608,7 +571,7 @@ class Manager:
 
             # Send it to the workers and let them know to load the
             # send package
-            for worker_id, worker_data in self.workers.items():
+            for worker_id, worker_data in self.state.workers.items():
 
                 # Create a temporary HTTP client
                 client = Client(
@@ -616,17 +579,18 @@ class Manager:
                     host=worker_data.ip,
                     port=worker_data.port,
                 )
-                client.send_file(sender_id=self.id, filepath=zip_package_dst)
+                client.send_file(sender_id=self.state.id, filepath=zip_package_dst)
 
         # Wail until all workers have responded with their node server data
         success = False
-        for worker_id in self.workers:
+        for worker_id in self.state.workers:
 
             for i in range(config.get("manager.allowed-failures")):
 
                 # Send package finish confirmation
                 r = requests.post(
-                    self.workers[worker_id]["url"] + "/packages/load",
+                    f"http://{self.state.workers[worker_id].ip}:{self.state.workers[worker_id].port}"
+                    + "/packages/load",
                     json.dumps({"packages": [x["name"] for x in packages_meta]}),
                     timeout=config.get("manager.timeout.package-delivery"),
                 )
@@ -725,10 +689,11 @@ class Manager:
 
         # Wail until all workers have responded with their node server data
         gather_data = {}
-        for worker_id in self.workers:
+        for worker_id in self.state.workers:
 
             r = requests.get(
-                self.workers[worker_id]["url"] + "/nodes/gather",
+                f"http://{self.state.workers[worker_id].ip}:{self.state.workers[worker_id].port}"
+                + "/nodes/gather",
                 timeout=config.get("manager.timeout.info-request"),
             )
             logger.debug(r)
@@ -797,7 +762,7 @@ class Manager:
         if success:
             for worker_id in self.state.workers:
                 for node_id in self.state.workers[worker_id].nodes:
-                    self.state.workers[worker_id].nodes[node_id].finished = True
+                    self.state.workers[worker_id].nodes[node_id].finished = 1
 
         # Request collecting archives
         success = self.broadcast_request(
@@ -832,7 +797,7 @@ class Manager:
 
         # If workers are connected, let's notify them that the cluster is
         # shutting down
-        if len(self.workers) > 0:
+        if len(self.state.workers) > 0:
 
             # Send shutdown message
             logger.debug(f"{self}: broadcasting shutdown via /shutdown route")
@@ -850,7 +815,7 @@ class Manager:
 
             # Wait until all worker's deregister
             success = waiting_for(
-                condition=lambda: len(self.workers) == 0,
+                condition=lambda: len(self.state.workers) == 0,
                 check_period=0.1,
                 timeout_raise=False,
                 timeout=config.get("manager.timeout.worker-shutdown"),

--- a/chimerapy/node.py
+++ b/chimerapy/node.py
@@ -19,6 +19,7 @@ import pandas as pd
 import zmq
 
 # Internal Imports
+from .states import NodeState
 from .networking import Client, Publisher, Subscriber, DataChunk
 from .networking.enums import GENERAL_MESSAGE, WORKER_MESSAGE, NODE_MESSAGE
 from .data_handlers import SaveHandler
@@ -51,9 +52,7 @@ class Node(mp.Process):
 
         # Saving input parameters
         self._context = mp.get_start_method()
-        self.name = name
-        self.id = str(uuid.uuid4())
-        self.status = {"INIT": 0, "CONNECTED": 0, "READY": 0, "FINISHED": 0}
+        self.state = NodeState(id=str(uuid.uuid4()), name=name)
 
         # Saving state variables
         self.publisher: Optional[Publisher] = None
@@ -102,11 +101,23 @@ class Node(mp.Process):
                 self.prep()
 
     ####################################################################
+    ## Properties
+    ####################################################################
+
+    @property
+    def id(self) -> str:
+        return self.state.id
+
+    @property
+    def name(self) -> str:
+        return self.state.name
+
+    ####################################################################
     ## Process Pickling Methods
     ####################################################################
 
     def __repr__(self):
-        return f"<Node name={self.name} id={self.id}>"
+        return f"<Node name={self.state.name} id={self.state.id}>"
 
     def __str__(self):
         return self.__repr__()
@@ -164,7 +175,7 @@ class Node(mp.Process):
         # We determine all the out bound nodes
         for i, in_bound_id in enumerate(self.p2p_info["in_bound"]):
 
-            self.logger.debug(f"{self}: Setting up clients: {self.id}: {msg}")
+            self.logger.debug(f"{self}: Setting up clients: {self.state.id}: {msg}")
 
             # Determine the host and port information
             in_bound_info = msg["data"][in_bound_id]
@@ -191,7 +202,7 @@ class Node(mp.Process):
             self.poll_inputs_thread.start()
 
         # Notify to the worker that the node is fully CONNECTED
-        self.status["CONNECTED"] = 1
+        self.state.connected = True
         self.connected_ready.set()
         await self.client.async_send(
             signal=NODE_MESSAGE.STATUS, data=self.state.to_dict()
@@ -212,10 +223,10 @@ class Node(mp.Process):
         # Stop the save handler
         self.save_handler.shutdown()
         self.save_handler.join()
-        self.status["FINISHED"] = 1
+        self.state.finished = True
 
         await self.client.async_send(
-            signal=NODE_MESSAGE.STATUS, data=self.state.to_dict()
+            signal=NODE_MESSAGE.STATUS, data=asdict(self.state)
         )
 
     async def start_node(self, msg: Dict):
@@ -313,7 +324,7 @@ class Node(mp.Process):
         # Obtaining worker information
         self.worker_host = host
         self.worker_port = port
-        self.logdir = logdir / self.name
+        self.logdir = logdir / self.state.name
         self.worker_logging_port = worker_logging_port
         os.makedirs(self.logdir, exist_ok=True)
 
@@ -360,7 +371,7 @@ class Node(mp.Process):
         self.step_id = 0
         self.worker_signal_start = threading.Event()
         self.worker_signal_start.clear()
-        self.status["INIT"] = 1
+        self.state.init = True
 
         if self.networking:
 
@@ -368,7 +379,7 @@ class Node(mp.Process):
             self.client = Client(
                 host=self.worker_host,
                 port=self.worker_port,
-                id=self.id,
+                id=self.state.id,
                 ws_handlers={
                     GENERAL_MESSAGE.SHUTDOWN: self.shutdown,
                     WORKER_MESSAGE.BROADCAST_NODE_SERVER_DATA: self.process_node_server_data,
@@ -387,6 +398,7 @@ class Node(mp.Process):
             # Creating publisher
             self.publisher = Publisher()
             self.publisher.start()
+            self.state.port = self.publisher.port
 
             # Creating threading event to mark that the Node has been connected
             self.connected_ready = threading.Event()
@@ -411,7 +423,7 @@ class Node(mp.Process):
     def ready(self):
 
         # Notify to the worker that the node is fully READY
-        self.status["READY"] = 1
+        self.state.ready = True
 
         # Only do so if connected to Worker and its connected
         if self.networking:
@@ -529,7 +541,7 @@ class Node(mp.Process):
                 # Add timestamp and step id to the DataChunk
                 meta = output_data_chunk.get("meta")
                 meta["value"]["ownership"].append(
-                    {"name": self.name, "timestamp": datetime.datetime.now()}
+                    {"name": self.state.name, "timestamp": datetime.datetime.now()}
                 )
                 output_data_chunk.update("meta", meta)
 
@@ -610,7 +622,7 @@ class Node(mp.Process):
         # Shutdown the inputs and outputs threads
         self.save_handler.shutdown()
         self.save_handler.join()
-        self.status["FINISHED"] = 1
+        self.state.finished = True
         self.logger.debug(f"{self}: save handler shutdown")
 
         # Shutting down networking

--- a/chimerapy/node.py
+++ b/chimerapy/node.py
@@ -194,12 +194,7 @@ class Node(mp.Process):
         self.status["CONNECTED"] = 1
         self.connected_ready.set()
         await self.client.async_send(
-            signal=NODE_MESSAGE.STATUS,
-            data={
-                "id": self.id,
-                "name": self.name,
-                "status": self.status,
-            },
+            signal=NODE_MESSAGE.STATUS, data=self.state.to_dict()
         )
 
     async def provide_gather(self, msg: Dict):
@@ -207,9 +202,8 @@ class Node(mp.Process):
         await self.client.async_send(
             signal=NODE_MESSAGE.REPORT_GATHER,
             data={
-                "id": self.id,
-                "name": self.name,
-                "latest_value": self.latest_value,
+                "state": self.state.to_dict(),
+                "latest_value": self.latest_value
             },
         )
 
@@ -221,12 +215,7 @@ class Node(mp.Process):
         self.status["FINISHED"] = 1
 
         await self.client.async_send(
-            signal=NODE_MESSAGE.STATUS,
-            data={
-                "id": self.id,
-                "name": self.name,
-                "status": self.status,
-            },
+            signal=NODE_MESSAGE.STATUS, data=self.state.to_dict()
         )
 
     async def start_node(self, msg: Dict):
@@ -406,13 +395,7 @@ class Node(mp.Process):
             # Send publisher port and host information
             self.client.send(
                 signal=NODE_MESSAGE.STATUS,
-                data={
-                    "id": self.id,
-                    "name": self.name,
-                    "status": self.status,
-                    "host": self.publisher.host,
-                    "port": self.publisher.port,
-                },
+                data=self.state.to_dict(),
             )
 
     def prep(self):
@@ -432,14 +415,7 @@ class Node(mp.Process):
 
         # Only do so if connected to Worker and its connected
         if self.networking:
-            self.client.send(
-                signal=NODE_MESSAGE.STATUS,
-                data={
-                    "id": self.id,
-                    "name": self.name,
-                    "status": self.status,
-                },
-            )
+            self.client.send(signal=NODE_MESSAGE.STATUS, data=self.state.to_dict())
 
     def waiting(self):
 
@@ -641,14 +617,7 @@ class Node(mp.Process):
         if self.networking:
 
             # Inform the worker that the Node has finished its saving of data
-            self.client.send(
-                signal=NODE_MESSAGE.STATUS,
-                data={
-                    "id": self.id,
-                    "name": self.name,
-                    "status": self.status,
-                },
-            )
+            self.client.send(signal=NODE_MESSAGE.STATUS, data=self.state.to_dict())
 
             # Shutdown the client
             self.client.shutdown()

--- a/chimerapy/node.py
+++ b/chimerapy/node.py
@@ -212,10 +212,7 @@ class Node(mp.Process):
 
         await self.client.async_send(
             signal=NODE_MESSAGE.REPORT_GATHER,
-            data={
-                "state": self.state.to_dict(),
-                "latest_value": self.latest_value
-            },
+            data={"state": self.state.to_dict(), "latest_value": self.latest_value},
         )
 
     async def provide_saving(self, msg: Dict):
@@ -226,7 +223,7 @@ class Node(mp.Process):
         self.state.finished = True
 
         await self.client.async_send(
-            signal=NODE_MESSAGE.STATUS, data=asdict(self.state)
+            signal=NODE_MESSAGE.STATUS, data=self.state.to_dict()
         )
 
     async def start_node(self, msg: Dict):

--- a/chimerapy/states.py
+++ b/chimerapy/states.py
@@ -1,0 +1,34 @@
+from typing import List, Dict
+from dataclasses import dataclass, field
+from dataclasses_json import dataclass_json
+
+
+@dataclass_json
+@dataclass
+class NodeState:
+    id: str
+    name: str = ""
+    init: bool = False
+    connected: bool = False
+    ready: bool = False
+    finished: bool = False
+    port: int = 0
+
+
+@dataclass_json
+@dataclass
+class WorkerState:
+    id: str
+    name: str
+    port: int = 0
+    ip: str = ""
+    nodes: Dict[str, NodeState] = field(default_factory=dict)
+
+
+@dataclass_json
+@dataclass
+class ManagerState:
+    id: str = ""
+    ip: str = ""
+    port: int = 0
+    workers: Dict[str, WorkerState] = field(default_factory=dict)

--- a/chimerapy/states.py
+++ b/chimerapy/states.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List, Dict, Optional
 from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json
 
@@ -32,3 +32,5 @@ class ManagerState:
     ip: str = ""
     port: int = 0
     workers: Dict[str, WorkerState] = field(default_factory=dict)
+
+    logs_subscription_port: Optional[int] = None

--- a/chimerapy/worker.py
+++ b/chimerapy/worker.py
@@ -76,6 +76,7 @@ class Worker:
         self.manager_ack: bool = False
         self.connected_to_manager: bool = False
         self.manager_host = "0.0.0.0"
+        self.manager_url = ""
 
         # Create temporary data folder
         self.delete_temp = delete_temp
@@ -483,17 +484,19 @@ class Worker:
         self.nodes[node_id]["response"] = True
 
         # Construct information of all the nodes to be send to the Manager
-        # nodes_status_data = {
-        #     "name": self.name,
-        #     "nodes_status": {k: self.nodes[k]["status"] for k in self.nodes},
-        # }
 
         # Update Manager on the new nodes status
-        # if self.connected_to_manager:
-        #     await self.client.async_send(
-        #         signal=WORKER_MESSAGE.REPORT_NODES_STATUS,
-        #         data=nodes_status_data,
-        #     )
+        if self.connected_to_manager:
+
+            msg = {
+                "id": self.id,
+                "name": self.name,
+                "node_status": {k: self.nodes[k]["status"] for k in self.nodes},
+            }
+
+            async with aiohttp.ClientSession(self.manager_url) as session:
+                async with session.post("/workers/node_status", data=json.dumps(msg)):
+                    pass
 
     ####################################################################
     ## Helper Methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     'simplejpeg',
     'aiohttp',
     'blosc',
-    'PyYAML'
+    'PyYAML',
+    'dataclasses-json'
 ]
 
 [project.optional-dependencies]

--- a/test/front_end_integration/test_routes.py
+++ b/test/front_end_integration/test_routes.py
@@ -23,4 +23,4 @@ def test_get_network(config_manager):
     route = f"http://{config_manager.host}:{config_manager.port}/network"
     r = requests.get(route)
     assert r.status_code == requests.codes.ok
-    assert r.json() == config_manager.dashboard_dict()
+    assert r.json() == config_manager.state.to_dict()

--- a/test/networking/test_code_delivery.py
+++ b/test/networking/test_code_delivery.py
@@ -65,4 +65,4 @@ def test_sending_package(manager, _worker, config_graph):
     )
 
     for node_id in config_graph.G.nodes():
-        assert manager.workers[_worker.id]["nodes_status"][node_id]["INIT"] == 1
+        assert manager.workers[_worker.id].nodes[node_id].init == True

--- a/test/networking/test_p2p_networking.py
+++ b/test/networking/test_p2p_networking.py
@@ -18,18 +18,18 @@ cp.debug()
         (lazy_fixture("single_node_no_connections_manager")),
         (lazy_fixture("multiple_nodes_one_worker_manager")),
         (lazy_fixture("multiple_nodes_multiple_workers_manager")),
-        pytest.param(
-            lazy_fixture("dockered_single_node_no_connections_manager"),
-            marks=linux_run_only,
-        ),
-        pytest.param(
-            lazy_fixture("dockered_multiple_nodes_one_worker_manager"),
-            marks=linux_run_only,
-        ),
-        pytest.param(
-            lazy_fixture("dockered_multiple_nodes_multiple_workers_manager"),
-            marks=linux_run_only,
-        ),
+        # pytest.param(
+        #     lazy_fixture("dockered_single_node_no_connections_manager"),
+        #     marks=linux_run_only,
+        # ),
+        # pytest.param(
+        #     lazy_fixture("dockered_multiple_nodes_one_worker_manager"),
+        #     marks=linux_run_only,
+        # ),
+        # pytest.param(
+        #     lazy_fixture("dockered_multiple_nodes_multiple_workers_manager"),
+        #     marks=linux_run_only,
+        # ),
     ],
 )
 def test_detecting_when_all_nodes_are_ready(config_manager):
@@ -42,13 +42,13 @@ def test_detecting_when_all_nodes_are_ready(config_manager):
         # Assert that the worker has their expected nodes
         expected_nodes = worker_node_map[worker_id]
         union = set(expected_nodes) | set(
-            config_manager.workers[worker_id]["nodes_status"].keys()
+            config_manager.workers[worker_id].nodes.keys()
         )
         assert len(union) == len(expected_nodes)
 
         # Assert that all the nodes should be INIT
-        for node_id in config_manager.workers[worker_id]["nodes_status"]:
-            assert config_manager.workers[worker_id]["nodes_status"][node_id]["INIT"]
+        for node_id in config_manager.workers[worker_id].nodes:
+            assert config_manager.workers[worker_id].nodes[node_id].init
             nodes_ids.append(node_id)
 
     logger.debug(f"After creation of p2p network workers: {config_manager.workers}")
@@ -59,10 +59,8 @@ def test_detecting_when_all_nodes_are_ready(config_manager):
     # Extract all the nodes
     nodes_ids = []
     for worker_id in config_manager.workers:
-        for node_id in config_manager.workers[worker_id]["nodes_status"]:
-            assert config_manager.workers[worker_id]["nodes_status"][node_id][
-                "CONNECTED"
-            ]
+        for node_id in config_manager.workers[worker_id].nodes:
+            assert config_manager.workers[worker_id].nodes[node_id].connected
             nodes_ids.append(node_id)
 
     # The config manager should have all the nodes registered as CONNECTED
@@ -71,8 +69,8 @@ def test_detecting_when_all_nodes_are_ready(config_manager):
     # Extract all the nodes
     nodes_idss = []
     for worker_id in config_manager.workers:
-        for node_id in config_manager.workers[worker_id]["nodes_status"]:
-            assert config_manager.workers[worker_id]["nodes_status"][node_id]["READY"]
+        for node_id in config_manager.workers[worker_id].nodes:
+            assert config_manager.workers[worker_id].nodes[node_id].ready
             nodes_idss.append(node_id)
 
     # The config manager should have all the nodes registered as READY

--- a/test/networking/test_p2p_networking.py
+++ b/test/networking/test_p2p_networking.py
@@ -18,18 +18,18 @@ cp.debug()
         (lazy_fixture("single_node_no_connections_manager")),
         (lazy_fixture("multiple_nodes_one_worker_manager")),
         (lazy_fixture("multiple_nodes_multiple_workers_manager")),
-        # pytest.param(
-        #     lazy_fixture("dockered_single_node_no_connections_manager"),
-        #     marks=linux_run_only,
-        # ),
-        # pytest.param(
-        #     lazy_fixture("dockered_multiple_nodes_one_worker_manager"),
-        #     marks=linux_run_only,
-        # ),
-        # pytest.param(
-        #     lazy_fixture("dockered_multiple_nodes_multiple_workers_manager"),
-        #     marks=linux_run_only,
-        # ),
+        pytest.param(
+            lazy_fixture("dockered_single_node_no_connections_manager"),
+            marks=linux_run_only,
+        ),
+        pytest.param(
+            lazy_fixture("dockered_multiple_nodes_one_worker_manager"),
+            marks=linux_run_only,
+        ),
+        pytest.param(
+            lazy_fixture("dockered_multiple_nodes_multiple_workers_manager"),
+            marks=linux_run_only,
+        ),
     ],
 )
 def test_detecting_when_all_nodes_are_ready(config_manager):

--- a/test/streams/test_transfer.py
+++ b/test/streams/test_transfer.py
@@ -28,7 +28,7 @@ NAME_CLASS_MAP = {
     "tn": TabularNode,
     "an": AudioNode,
 }
-NUM_OF_WORKERS = 5
+NUM_OF_WORKERS = 3
 
 
 @pytest.fixture
@@ -205,7 +205,5 @@ def test_manager_worker_data_transfer(config_manager, expected_number_of_folders
     )
     assert (config_manager.logdir / "meta.json").exists()
     for worker_id in config_manager.workers:
-        for node_id in config_manager.workers[worker_id]["nodes_status"]:
-            assert config_manager.workers[worker_id]["nodes_status"][node_id][
-                "FINISHED"
-            ]
+        for node_id in config_manager.workers[worker_id].nodes:
+            assert config_manager.workers[worker_id].nodes[node_id].finished

--- a/test/test_worker_node_interactions.py
+++ b/test/test_worker_node_interactions.py
@@ -157,7 +157,7 @@ def test_worker_create_node(worker, gen_node):
 
     logger.debug("Finishied creating nodes")
     assert gen_node.id in worker.nodes
-    assert isinstance(worker.nodes[gen_node.id]["node_object"], cp.Node)
+    assert isinstance(worker.nodes_extra[gen_node.id]["node_object"], cp.Node)
 
 
 @linux_expected_only
@@ -184,7 +184,7 @@ def test_worker_create_unknown_node(worker):
 
     logger.debug("Finishied creating nodes")
     assert node.id in worker.nodes
-    assert isinstance(worker.nodes[node.id]["node_object"], cp.Node)
+    assert isinstance(worker.nodes_extra[node.id]["node_object"], cp.Node)
 
 
 def test_worker_create_multiple_node(worker):


### PR DESCRIPTION
Decomposition of PR #102, having the changes pertaining to the booking of system state. Including the following:

* Refactored the state information into proper dataclasses for Manager, Worker, and Node
* Updated cluster orchestration methods (e.g. commit, gather, collect) to use the new state dataclasses
* Updated GET /network route to return JSON of ManagerState, which includes all WorkerState and NodeState
* Updated test to use the new state variables
* Made state attributes accessible through Python decorators (to avoid having to access like this:manager.state.ip)