### PR TITLE
Handling unstable video fps in ``VideoRecord`` and ``Node``'s video saving API. Closes #77

### DIFF
--- a/chimerapy/node.py
+++ b/chimerapy/node.py
@@ -231,6 +231,7 @@ class Node(mp.Process):
 
     async def start_node(self, msg: Dict):
         self.logger.debug(f"{self}: start")
+        self.start_time = datetime.datetime.now()
         self.worker_signal_start.set()
 
     async def async_forward(self, msg: Dict):
@@ -250,6 +251,7 @@ class Node(mp.Process):
             "data": data,
             "dtype": "video",
             "fps": fps,
+            "timestamp": (datetime.datetime.now() - self.start_time).total_seconds(),
         }
         self.save_queue.put(video_chunk)
 
@@ -345,6 +347,9 @@ class Node(mp.Process):
 
         # Creating initial values
         self.latest_value = None
+
+        # Timekeeping
+        self.start_time = datetime.datetime.now()
 
     def _prep(self):
         """Establishes the connection between ``Node`` and ``Worker``

--- a/test/streams/test_video.py
+++ b/test/streams/test_video.py
@@ -9,6 +9,7 @@ import queue
 import uuid
 
 # Third-party
+import cv2
 import numpy as np
 import pytest
 import chimerapy as cp
@@ -64,11 +65,64 @@ def test_video_record():
             "data": data,
             "dtype": "video",
             "fps": fps,
+            "timestamp": i / fps,
         }
         vr.write(video_chunk)
 
+    # Close file
+    vr.close()
+
     # Check that the video was created
     assert expected_video_path.exists()
+
+    # Check video attributes
+    cap = cv2.VideoCapture(str(expected_video_path))
+    num_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    assert num_frames == fps
+
+
+def test_video_record_with_unstable_frames():
+
+    # Check that the video was created
+    expected_video_path = TEST_DATA_DIR / "test.mp4"
+    try:
+        os.remove(expected_video_path)
+    except FileNotFoundError:
+        ...
+
+    # Create the record
+    vr = cp.records.VideoRecord(dir=TEST_DATA_DIR, name="test")
+
+    # Write to video file
+    fps = 30
+    actual_fps = 10
+    rec_time = 5
+    for i in range(rec_time * actual_fps):
+
+        # But actually, we are getting frames at 20 fps
+        timestamp = i / actual_fps
+        data = np.random.rand(200, 300, 3) * 255
+        video_chunk = {
+            "uuid": uuid.uuid4(),
+            "name": "test",
+            "data": data,
+            "dtype": "video",
+            "fps": fps,
+            "timestamp": timestamp,
+        }
+        vr.write(video_chunk)
+
+    # Close file
+    vr.close()
+
+    # Check that the video was created
+    assert expected_video_path.exists()
+
+    # Check video attributes
+    cap = cv2.VideoCapture(str(expected_video_path))
+    num_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    expected_num_frames = fps * rec_time
+    assert (num_frames - expected_num_frames) / expected_num_frames <= 0.02
 
 
 def test_save_handler_video(save_handler_and_queue):
@@ -93,6 +147,7 @@ def test_save_handler_video(save_handler_and_queue):
             "data": data,
             "dtype": "video",
             "fps": fps,
+            "timestamp": i / fps,
         }
 
         save_queue.put(video_chunk)
@@ -145,3 +200,35 @@ def test_node_save_video_stream(video_node_stream, logreceiver):
 
     # Check that the video was created
     assert expected_video_path.exists()
+
+
+def test_node_save_video_stream_with_unstable_fps(video_node_stream, logreceiver):
+
+    # Check that the video was created
+    expected_video_path = video_node_stream.logdir / "test.mp4"
+    try:
+        os.remove(expected_video_path)
+    except FileNotFoundError:
+        ...
+
+    # Video parameters (located within the VideoNode)
+    fps = 30  # actual at 1/10
+    rec_time = 10
+
+    # Stream
+    video_node_stream.start()
+
+    # Wait to generate files
+    time.sleep(rec_time)
+
+    video_node_stream.shutdown()
+    video_node_stream.join()
+
+    # Check that the video was created
+    assert expected_video_path.exists()
+
+    # Check video attributes
+    cap = cv2.VideoCapture(str(expected_video_path))
+    num_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    expected_num_frames = fps * rec_time
+    assert (num_frames - expected_num_frames) / expected_num_frames <= 0.02


### PR DESCRIPTION
Added ``timestamp`` to ``video_chunk`` when saving video into a record. Using the ``timestamp``, ``Node``'s ``start_time``, and ``fps`` parameter, the ``VideoRecord`` can now correct for unstable fps, via frame padding or downsampling.