### PR TITLE
Use `Queue` based `Listener` to communicate logs from `Node` to `Worker`. Closes #122

### DIFF
--- a/chimerapy/logger/common.py
+++ b/chimerapy/logger/common.py
@@ -1,0 +1,28 @@
+import logging
+from logging import Formatter, StreamHandler
+
+
+class HandlerFactory:
+    """Utility class to create logging handlers"""
+
+    @staticmethod
+    def get(name, level=logging.DEBUG) -> logging.Handler:
+        if name == "console":
+            hdlr = HandlerFactory.get_console_handler()
+        else:
+            raise ValueError(f"Unknown handler name: {name}")
+        hdlr.setLevel(level)
+        return hdlr
+
+    @staticmethod
+    def get_console_handler() -> logging.StreamHandler:
+        console_handler = StreamHandler()
+        console_handler.setFormatter(HandlerFactory.get_formatter())
+        return console_handler
+
+    @staticmethod
+    def get_formatter() -> logging.Formatter:
+        return Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )

--- a/chimerapy/logger/portable_queue.py
+++ b/chimerapy/logger/portable_queue.py
@@ -1,0 +1,95 @@
+import multiprocessing as mp
+import queue
+
+
+class SharedCounter:
+    """A synchronized shared counter.
+    The locking done by multiprocessing.Value ensures that only a single
+    process or thread may read or write the in-memory ctypes object. However,
+    in order to do n += 1, Python performs a read followed by a write, so a
+    second process may read the old value before the new one is written by the
+    first process. The solution is to use a multiprocessing.Lock to guarantee
+    the atomicity of the modifications to Value.
+    This class comes almost entirely from Eli Bendersky's blog:
+    http://eli.thegreenplace.net/2012/01/04/shared-counter-with-pythons-multiprocessing/
+    """
+
+    def __init__(self, n=0):
+        self.count = mp.Value("i", n)
+
+    def increment(self, n=1):
+        """Increment the counter by n (default = 1)"""
+        with self.count.get_lock():
+            self.count.value += n
+
+    @property
+    def value(self):
+        """Return the value of the counter"""
+        return self.count.value
+
+
+class PortableQueue(mp.Queue):
+    """A portable implementation of multiprocessing.Queue.
+    Because of multithreading / multiprocessing semantics, Queue.qsize() may
+    raise the NotImplementedError exception on Unix platforms like Mac OS X
+    where sem_getvalue() is not implemented. This subclass addresses this
+    problem by using a synchronized shared counter (initialized to zero) and
+    increasing / decreasing its value every time the put() and get() methods
+    are called, respectively. This not only prevents NotImplementedError from
+    being raised, but also allows us to implement a reliable version of both
+    qsize() and empty().
+
+    Code acquired from:
+    https://github.com/vterron/lemon/blob/d60576bec2ad5d1d5043bcb3111dff1fcb58a8d6/methods.py#L536-L573
+
+    According to the StackOver post here:
+    https://stackoverflow.com/questions/65609529/python-multiprocessing-queue-notimplementederror-macos
+
+    Fixing the `size` not an attribute of Queue can be found here:
+    https://stackoverflow.com/questions/69897765/cannot-access-property-of-subclass-of-multiprocessing-queues-queue-in-multiproce
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, ctx=mp.get_context())
+        self.size = SharedCounter(0)
+
+    def __getstate__(self):
+        return super().__getstate__() + (self.size,)
+
+    def __setstate__(self, state):
+        super().__setstate__(state[:-1])
+        self.size = state[-1]
+
+    def put(self, *args, **kwargs):
+
+        # Have to account for timeout to make this implementation
+        # faithful to the complete mp.Queue implementation.
+        try:
+            super().put(*args, **kwargs)
+            self.size.increment(1)
+        except queue.Full:
+            raise queue.Full
+
+    def get(self, *args, **kwargs):
+
+        # Have to account for timeout to make this implementation
+        # faithful to the complete mp.Queue implementation.
+        try:
+            data = super().get(*args, **kwargs)
+            self.size.increment(-1)
+            return data
+        except queue.Empty:
+            raise queue.Empty
+
+    def qsize(self):
+        """Reliable implementation of multiprocessing.Queue.qsize()"""
+        return self.size.value
+
+    def empty(self):
+        """Reliable implementation of multiprocessing.Queue.empty()"""
+        return not self.qsize()
+
+    def clear(self):
+        """Remove all elements from the Queue."""
+        while not self.empty():
+            self.get()

--- a/chimerapy/logger/queued_handler.py
+++ b/chimerapy/logger/queued_handler.py
@@ -1,0 +1,68 @@
+import logging
+from logging.handlers import QueueHandler, QueueListener
+from typing import Tuple
+
+from .common import HandlerFactory
+from .portable_queue import PortableQueue as Queue
+
+LISTENER_QUEUES = dict()
+
+
+class LogsQueueHandler:
+    """A queue handler that can be used to send logs to a process safe queue."""
+
+    def __init__(
+        self, handlers: Tuple[str, ...] = ("console",), level: int = logging.DEBUG
+    ):
+        queue = Queue(-1)
+        super().__init__(queue)
+        handlers = [HandlerFactory.get(handler, level) for handler in handlers]
+        self.listener = QueueListener(queue, *handlers, respect_handler_level=True)
+
+    def start(self) -> None:
+        self.listener.start()
+
+    def stop(self) -> None:
+        self.listener.stop()
+
+    def is_listening(self) -> bool:
+        return hasattr(self.listener, "_thread") and self.listener._thread.is_alive()
+
+    def add_queue_handler(self, logger) -> None:
+        existing_handlers = filter(
+            lambda h: isinstance(h, QueueHandler), logger.handlers
+        )
+        map(logger.removeHandler, existing_handlers)
+        if not self.is_listening():
+            self.start()
+
+        hdlr = QueueHandler(self.listener.queue)
+        hdlr.setLevel(logger.level)
+        logger.addHandler(hdlr)
+
+
+def start_logs_queue_listener(queue_id: str) -> None:
+    """Register a new queue handler for the given queue_id."""
+    LISTENER_QUEUES[queue_id] = LogsQueueHandler()
+    LISTENER_QUEUES[queue_id].start()
+
+
+def add_queue_handler(queue_id, logger: logging.Logger):
+    """Given a queue_id and a logger, add a queue handler to the logger."""
+    if queue_id not in LISTENER_QUEUES:
+        raise ValueError(
+            f"Queue {queue_id} not found. Please call start_queue_handler first."
+        )
+
+    LISTENER_QUEUES[queue_id].add_queue_handler(logger)
+
+
+def stop_logs_queue_listener(queue_id: str) -> None:
+    """Stop the queue handler for the given queue_id."""
+    if queue_id not in LISTENER_QUEUES:
+        raise ValueError(
+            f"Queue {queue_id} not found. Please call start_queue_handler first."
+        )
+
+    LISTENER_QUEUES[queue_id].stop()
+    del LISTENER_QUEUES[queue_id]


### PR DESCRIPTION
## Checklist
- [x] Add queued handlers/listeners
- [ ] Change current datagram based handlers to use the queue handler
- [ ] Change log receiver to a queue listener
- [ ] Modify pertinent tests 