### PR TITLE
Use `log_file` for capturing test logs. Closes #128

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,14 @@ jobs:
 
       - name: Perform tests
         run: |
-          coverage run --source=chimerapy -m pytest --reruns 5 --reruns-delay 5 test/
+          coverage run --source=chimerapy -m pytest --reruns 5 --reruns-delay 5 test/test_logging.py
           coverage combine
+
+      - name: Upload test log as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: chimerapy-test.log
+          path: test.log
 
       - name: Upload coverage data to coveralls.io
         if : matrix.os == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Perform tests
         run: |
-          coverage run --source=chimerapy -m pytest --reruns 5 --reruns-delay 5 test/test_logging.py
+          coverage run --source=chimerapy -m pytest --reruns 5 --color yes --reruns-delay 5 test
           coverage combine
 
       - name: Upload test log as artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Upload test log as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: chimerapy-test.log
-          path: test.log
+          name: chimerapy-test-${{ env.MANUAL_OS_SET }}.log
+          path: chimerapy-test.log
 
       - name: Upload coverage data to coveralls.io
         if : matrix.os == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Perform tests
         run: |
-          coverage run --source=chimerapy -m pytest --reruns 5 --color yes --reruns-delay 5 test
+          coverage run --source=chimerapy -m pytest -v --reruns 5 --color yes --reruns-delay 5 test
           coverage combine
 
       - name: Upload test log as artifact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,10 +96,16 @@ chimerapy = ['*.yaml']
 [tool.pytest.ini_options]
 
 # Logging + CLI
-log_cli = true
+log_cli = false
 log_cli_level = "DEBUG"
 log_cli_format = "%(asctime)s.%(msecs)03d [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+
+# Logging + File
+log_file = "chimerapy-test.log"
+log_file_level = "DEBUG"
+log_file_format = "%(asctime)s.%(msecs)03d [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_file_date_format = "%Y-%m-%d %H:%M:%S"
 
 # Timeout
 faulthandler_timeout=300


### PR DESCRIPTION
## Core Changes
- [x] Disable CLI logs capture
- [x] Enable Log File Based logs caputre
- [x] Upload log generated during test as an artifact. 

## Other Changes
- [x] Sensible pytest output with `-v` flag (since no logs now)
- [x] color = yes (ofcourse yes)