### PR TITLE
Add ruff as a pre-commit hook. Closes #100

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,9 @@ repos:
     rev: 22.3.0
     hooks:
     -   id: black
+
+-   repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.257'
+    hooks:
+    -   id: ruff
+        args: [--fix]

--- a/chimerapy/__init__.py
+++ b/chimerapy/__init__.py
@@ -1,15 +1,21 @@
-# populate fields for >>>help(imagezmq)
-from .__version__ import __title__, __description__, __url__, __version__
-from .__version__ import __author__, __author_email__, __license__
-from .__version__ import __copyright__
-
+# noqa E402
 # Package Setup
 from . import _logger
+from .__version__ import (
+    __author__,
+    __author_email__,
+    __copyright__,
+    __description__,
+    __license__,
+    __title__,
+    __url__,
+    __version__,
+)
 
 _logger.setup()
 
 # Handling the configuration
-from . import config
+from . import config  # noqa F401
 
 # Interal Imports
 from .manager import Manager

--- a/chimerapy/_debug.py
+++ b/chimerapy/_debug.py
@@ -1,7 +1,7 @@
 # Built-in Import
-from typing import List, Optional
 import logging
 import os
+from typing import List, Optional
 
 # Internal Imports
 from ._logger import LOGGING_CONFIG
@@ -13,7 +13,7 @@ def debug(loggers: Optional[List[str]] = None):
     if type(loggers) == type(None):
         loggers = [x for x in LOGGING_CONFIG["loggers"]]
 
-    assert loggers != None
+    assert loggers is not None
 
     # Change env variable and configurations
     os.environ["CHIMERAPY_DEBUG_LOGGERS"] = os.pathsep.join(loggers)

--- a/chimerapy/config.py
+++ b/chimerapy/config.py
@@ -1,7 +1,7 @@
 # Built-in Imports
-from typing import Dict, Any
-import pathlib
 import os
+import pathlib
+from typing import Any, Dict
 
 # Third-party Imports
 import yaml

--- a/chimerapy/data_handlers.py
+++ b/chimerapy/data_handlers.py
@@ -1,16 +1,13 @@
-from typing import Dict, List
 import pathlib
-import logging
-import threading
 import queue
-import uuid
+import threading
 
 from . import _logger
 
-logger = _logger.getLogger("chimerapy")
-
 # Internal Imports
-from .records import VideoRecord, AudioRecord, TabularRecord, ImageRecord
+from .records import AudioRecord, ImageRecord, TabularRecord, VideoRecord
+
+logger = _logger.getLogger("chimerapy")
 
 
 class SaveHandler(threading.Thread):

--- a/chimerapy/graph.py
+++ b/chimerapy/graph.py
@@ -1,13 +1,11 @@
-from typing import Sequence, Tuple
 import copy
-import logging
-import pdb
+from typing import Sequence
 
-import numpy as np
 import networkx as nx
+import numpy as np
 
-from .node import Node
 from . import _logger
+from .node import Node
 
 logger = _logger.getLogger("chimerapy")
 
@@ -91,7 +89,7 @@ class Graph:
         node_labels = {id: data["object"].name for id, data in self.G.nodes(data=True)}
 
         # Draw the networkx
-        fig = plt.figure(figsize=(20, 10))
+        fig = plt.figure(figsize=(20, 10))  # noqa F841
         nx.draw_networkx(
             self.G,
             pos,

--- a/chimerapy/manager.py
+++ b/chimerapy/manager.py
@@ -1,29 +1,28 @@
-from typing import Dict, Optional, List, Union, Any, Literal
-import pickle
-import pathlib
-import os
-import time
+import concurrent.futures
 import datetime
 import json
+import os
+import pathlib
+import pickle
 import random
 import tempfile
 import zipfile
-import concurrent.futures
 from concurrent.futures import Future
+from typing import Any, Dict, List, Literal, Optional, Union
 
 # Third-party Imports
 import dill
-import aiohttp
-from aiohttp import web
 import networkx as nx
 import requests
+from aiohttp import web
 
 from chimerapy import config
-from .states import ManagerState, WorkerState, NodeState
-from .networking import Server, Client, DataChunk
-from .graph import Graph
-from .exceptions import CommitGraphError
+
 from . import _logger
+from .exceptions import CommitGraphError
+from .graph import Graph
+from .networking import Client, DataChunk, Server
+from .states import ManagerState, NodeState, WorkerState
 from .utils import waiting_for
 
 logger = _logger.getLogger("chimerapy")
@@ -805,7 +804,7 @@ class Manager:
                     "/shutdown",
                     timeout=config.get("manager.timeout.worker-shutdown"),
                 )
-            except:
+            except:  # noqa: E722
                 pass
             logger.debug(
                 f"{self}: requested all workers to shutdown via /shutdown route"

--- a/chimerapy/networking/__init__.py
+++ b/chimerapy/networking/__init__.py
@@ -1,10 +1,9 @@
 # Class Imports
-from .async_loop_thread import AsyncLoopThread
-from .client import Client
-from .server import Server
-from .publisher import Publisher
-from .subscriber import Subscriber
-from .data_chunk import DataChunk
-
 # Utils Imports
 from . import enums
+from .async_loop_thread import AsyncLoopThread
+from .client import Client
+from .data_chunk import DataChunk
+from .publisher import Publisher
+from .server import Server
+from .subscriber import Subscriber

--- a/chimerapy/networking/async_loop_thread.py
+++ b/chimerapy/networking/async_loop_thread.py
@@ -1,8 +1,8 @@
 # Built-in
-from typing import Coroutine, Callable, Tuple, List, Optional, Any
-import threading
 import asyncio
+import threading
 from functools import partial
+from typing import Any, Callable, Coroutine, List, Optional, Tuple
 
 # Internal Imports
 from .. import _logger

--- a/chimerapy/networking/client.py
+++ b/chimerapy/networking/client.py
@@ -11,7 +11,7 @@ import threading
 import time
 import uuid
 from functools import partial
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 # Third-party
 import aiohttp

--- a/chimerapy/networking/client.py
+++ b/chimerapy/networking/client.py
@@ -1,30 +1,29 @@
 # Built-in
-from typing import Coroutine, Dict, Optional, Callable, Any, Union
 import asyncio
-import threading
 import collections
-import uuid
-import pathlib
-from functools import partial
-import shutil
-import time
-import tempfile
-import pickle
 import enum
 import logging
+import pathlib
+import pickle
+import shutil
+import tempfile
+import threading
+import time
+import uuid
+from functools import partial
+from typing import Any, Callable, Dict
 
 # Third-party
 import aiohttp
-from aiohttp import web
 
 # Internal Imports
 from chimerapy import config
-from .async_loop_thread import AsyncLoopThread
-from ..utils import create_payload, decode_payload, waiting_for, async_waiting_for
-from .enums import GENERAL_MESSAGE
 
 # Logging
 from .. import _logger
+from ..utils import async_waiting_for, create_payload, waiting_for
+from .async_loop_thread import AsyncLoopThread
+from .enums import GENERAL_MESSAGE
 
 logger = _logger.getLogger("chimerapy-networking")
 
@@ -190,7 +189,7 @@ class Client:
             try:
                 shutil.make_archive(str(dir), "zip", dir.parent, dir.name)
                 break
-            except:
+            except:  # noqa: E722
                 await asyncio.sleep(delay)
                 miss_counter += 1
 
@@ -356,7 +355,7 @@ class Client:
             try:
                 shutil.make_archive(str(dir), "zip", dir.parent, dir.name)
                 break
-            except:
+            except:  # noqa: E722
                 time.sleep(delay)
                 miss_counter += 1
 

--- a/chimerapy/networking/data_chunk.py
+++ b/chimerapy/networking/data_chunk.py
@@ -1,8 +1,9 @@
-from typing import Any, Literal, Dict, List
 import collections
-import pickle
-import blosc
 import datetime
+import pickle
+from typing import Any, Dict, List, Literal
+
+import blosc
 
 # Third-party Imports
 import numpy as np

--- a/chimerapy/networking/enums.py
+++ b/chimerapy/networking/enums.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 # Server <--> Client
 class GENERAL_MESSAGE(Enum):  # Used only Client and Server
     SHUTDOWN = -1

--- a/chimerapy/networking/publisher.py
+++ b/chimerapy/networking/publisher.py
@@ -1,6 +1,5 @@
 # Built-in Imports
 import threading
-import pickle
 import time
 
 # Third-party Imports
@@ -8,11 +7,11 @@ import zmq
 
 # Internal Imports
 from chimerapy import config
-from .data_chunk import DataChunk
-from ..utils import get_ip_address
 
 # Logging
 from .. import _logger
+from ..utils import get_ip_address
+from .data_chunk import DataChunk
 
 logger = _logger.getLogger("chimerapy-networking")
 
@@ -61,7 +60,7 @@ class Publisher:
         self._zmq_context = zmq.Context()
         self._zmq_socket = self._zmq_context.socket(zmq.PUB)
         self.port = self._zmq_socket.bind_to_random_port(f"tcp://{self.host}")
-        time.sleep(config.get('comms.timeout.pub-delay'))
+        time.sleep(config.get("comms.timeout.pub-delay"))
 
         # Create send thread
         self._ready = threading.Event()

--- a/chimerapy/networking/server.py
+++ b/chimerapy/networking/server.py
@@ -1,35 +1,34 @@
 # Built-in
-from typing import Callable, Dict, Optional, Any, Union, List
 import asyncio
-import threading
-import uuid
 import collections
-import time
-from functools import partial
-import pathlib
-import tempfile
-import shutil
-import os
-import pickle
 import enum
+import os
+import pathlib
+import pickle
+import shutil
+import tempfile
+import threading
+import time
+import uuid
+from functools import partial
+from typing import Any, Callable, Dict, List
 
 # Third-party
-from aiohttp import web, WSCloseCode
+from aiohttp import WSCloseCode, web
 
 # Internal Imports
 from chimerapy import config
-from .async_loop_thread import AsyncLoopThread
-from ..utils import (
-    decode_payload,
-    create_payload,
-    async_waiting_for,
-    waiting_for,
-    get_ip_address,
-)
-from .enums import GENERAL_MESSAGE
 
 # Logging
 from .. import _logger
+from ..utils import (
+    async_waiting_for,
+    create_payload,
+    get_ip_address,
+    waiting_for,
+)
+from .async_loop_thread import AsyncLoopThread
+from .enums import GENERAL_MESSAGE
 
 logger = _logger.getLogger("chimerapy-networking")
 

--- a/chimerapy/networking/server.py
+++ b/chimerapy/networking/server.py
@@ -3,6 +3,7 @@ import asyncio
 import collections
 import enum
 import os
+import logging
 import pathlib
 import pickle
 import shutil
@@ -11,7 +12,7 @@ import threading
 import time
 import uuid
 from functools import partial
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 # Third-party
 from aiohttp import WSCloseCode, web
@@ -48,7 +49,7 @@ class Server:
         host: str = get_ip_address(),
         routes: List[web.RouteDef] = [],
         ws_handlers: Dict[enum.Enum, Callable] = {},
-        parent_logger: Optional["Logger"] = None,
+        parent_logger: Optional[logging.Logger] = None,
     ):
         """Create HTTP Server with WS support.
 

--- a/chimerapy/networking/subscriber.py
+++ b/chimerapy/networking/subscriber.py
@@ -1,17 +1,15 @@
 # Built-in
-from typing import Optional, Union
 import threading
-import pickle
-import datetime
+from typing import Optional, Union
 
 # Third-party Imports
 import zmq
 
-# Internal Imports
-from .data_chunk import DataChunk
-
 # Logging
 from .. import _logger
+
+# Internal Imports
+from .data_chunk import DataChunk
 
 logger = _logger.getLogger("chimerapy-networking")
 

--- a/chimerapy/node.py
+++ b/chimerapy/node.py
@@ -1,29 +1,28 @@
-from typing import Dict, List, Any, Optional, Union, Literal, Tuple
-from multiprocessing.process import AuthenticationString
-import logging
-import queue
-import uuid
-import pathlib
-import os
-import tempfile
 import datetime
+import logging
+import os
+import pathlib
+import queue
+import tempfile
 import threading
 import traceback
 import uuid
+from multiprocessing.process import AuthenticationString
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 # Third-party Imports
-from dataclasses import dataclass
 import multiprocess as mp
 import numpy as np
 import pandas as pd
 import zmq
 
+from . import _logger
+from .data_handlers import SaveHandler
+from .networking import Client, DataChunk, Publisher, Subscriber
+from .networking.enums import GENERAL_MESSAGE, NODE_MESSAGE, WORKER_MESSAGE
+
 # Internal Imports
 from .states import NodeState
-from .networking import Client, Publisher, Subscriber, DataChunk
-from .networking.enums import GENERAL_MESSAGE, WORKER_MESSAGE, NODE_MESSAGE
-from .data_handlers import SaveHandler
-from . import _logger
 
 
 class Node(mp.Process):
@@ -138,7 +137,7 @@ class Node(mp.Process):
         self.__dict__.update(state)
 
     def get_logger(self) -> logging.Logger:
-        l = _logger.getLogger("chimerapy-node")
+        l = _logger.getLogger("chimerapy-node")  # noqa E741
         l.setLevel(self.logging_level)
         if self.worker_logging_port:
             _logger.add_node_id_zmq_push_handler(
@@ -482,7 +481,7 @@ class Node(mp.Process):
         if len(self.p2p_info["in_bound"]) == 0:
             try:
                 output = self.step()
-            except Exception as e:
+            except:  # noqa: E722
                 traceback_info = traceback.format_exc()
                 self.logger.error(traceback_info)
                 return None
@@ -502,7 +501,7 @@ class Node(mp.Process):
                     try:
                         output = self.step(self.in_bound_data)
                         break
-                    except Exception as e:
+                    except:  # noqa: E722
                         traceback_info = traceback.format_exc()
                         self.logger.error(traceback_info)
                         return None
@@ -641,7 +640,7 @@ class Node(mp.Process):
         # User-defined, possible error
         try:
             self.prep()
-        except Exception as e:
+        except:  # noqa: E722
             traceback_info = traceback.format_exc()
             self.logger.error(traceback_info)
             return None

--- a/chimerapy/records/__init__.py
+++ b/chimerapy/records/__init__.py
@@ -1,4 +1,4 @@
-from .video_record import VideoRecord
 from .audio_record import AudioRecord
-from .tabular_record import TabularRecord
 from .image_record import ImageRecord
+from .tabular_record import TabularRecord
+from .video_record import VideoRecord

--- a/chimerapy/records/audio_record.py
+++ b/chimerapy/records/audio_record.py
@@ -1,12 +1,11 @@
 # Built-in Imports
-from typing import Dict, Any
 import pathlib
-import os
+import wave
+from typing import Any, Dict
 
 # Third-party Imports
 import numpy as np
 import pyaudio
-import wave
 
 # Internal Imports
 from .record import Record

--- a/chimerapy/records/image_record.py
+++ b/chimerapy/records/image_record.py
@@ -1,7 +1,7 @@
 # Built-in Imports
-from typing import Dict, Any
-import pathlib
 import os
+import pathlib
+from typing import Any, Dict
 
 # Third-party Imports
 import cv2

--- a/chimerapy/records/record.py
+++ b/chimerapy/records/record.py
@@ -1,5 +1,4 @@
 # Built-in Imports
-from typing import Dict
 
 
 class Record:

--- a/chimerapy/records/tabular_record.py
+++ b/chimerapy/records/tabular_record.py
@@ -1,6 +1,6 @@
 # Built-in Imports
-from typing import Dict, Any
 import pathlib
+from typing import Any, Dict
 
 # Third-party Imports
 import pandas as pd

--- a/chimerapy/records/video_record.py
+++ b/chimerapy/records/video_record.py
@@ -1,11 +1,11 @@
 # Built-in Imports
-from typing import Dict, Any
 import pathlib
-import os
+from typing import Any, Dict
+
+import cv2
 
 # Third-party Imports
 import numpy as np
-import cv2
 
 # Internal Imports
 from .record import Record

--- a/chimerapy/states.py
+++ b/chimerapy/states.py
@@ -1,5 +1,6 @@
-from typing import List, Dict, Optional
 from dataclasses import dataclass, field
+from typing import Dict, Optional
+
 from dataclasses_json import dataclass_json
 
 

--- a/chimerapy/utils.py
+++ b/chimerapy/utils.py
@@ -1,20 +1,19 @@
-from typing import Callable, Union, Optional, Any, Dict
-import queue
-import logging
-import functools
-import json
-import time
-import enum
-import pickle
-import datetime
-import uuid
-import socket
 import asyncio
+import datetime
+import enum
+import errno
+import json
+import logging
+import queue
+import socket
+import time
+import uuid
+from typing import Any, Callable, Dict, Optional, Union
+
+import netifaces as ni
 
 # Third-party
 from tqdm import tqdm
-import blosc
-import netifaces as ni
 
 # Internal
 from . import _logger
@@ -33,10 +32,10 @@ def clear_queue(input_queue: queue.Queue):
         # Make sure to account for possible atomic modification of the
         # queue
         try:
-            data = input_queue.get(timeout=0.1, block=False)
+            data = input_queue.get(timeout=0.1, block=False)  # noqa: F841
             del data
         except queue.Empty:
-            logger.debug(f"clear_queue: empty!")
+            logger.debug("clear_queue: empty!")
             return
         except EOFError:
             logger.warning("Queue EOFError --- data corruption")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.abspath("./source/"))
 
 # As recommended by SO form:
 # https://stackoverflow.com/questions/63261090/github-sphinx-action-cant-find-target-python-modules-and-builds-an-empty-sphinx
-import chimerapy
+import chimerapy  # noqa: F401
 
 # -- Project information -----------------------------------------------------
 

--- a/examples/remote_camera.py
+++ b/examples/remote_camera.py
@@ -1,9 +1,8 @@
-from typing import Dict, Any
-import time
-import pathlib
 import os
+import pathlib
+import time
+from typing import Dict
 
-import numpy as np
 import cv2
 
 import chimerapy as cp

--- a/examples/remote_screen_and_web.py
+++ b/examples/remote_screen_and_web.py
@@ -1,12 +1,12 @@
-from typing import Dict, Any
-import time
-import pathlib
 import os
+import pathlib
 import platform
+import time
+from typing import Dict
 
-import numpy as np
 import cv2
 import imutils
+import numpy as np
 from PIL import ImageGrab
 
 import chimerapy as cp
@@ -112,7 +112,7 @@ if __name__ == "__main__":
 
         # For mutliple workers (remote and local)
         graph = cp.Graph()
-        show_node = ShowWindow(name=f"show")
+        show_node = ShowWindow(name="show")
         graph.add_node(show_node)
         mapping = {worker.id: [show_node.id]}
 

--- a/examples/remote_simple.py
+++ b/examples/remote_simple.py
@@ -1,10 +1,7 @@
-from typing import Dict, Any
-import time
-import pathlib
 import os
-
-import cv2
-import imutils
+import pathlib
+import time
+from typing import Any, Dict
 
 import chimerapy as cp
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,3 +118,13 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "unit: marks tests as unit tests (deselect with '-m \"not unit\"')"
 ]
+
+[tool.ruff]
+ignore = ["E501"]
+ignore-init-module-imports = true
+fixable = ["I001"]  # isort fix only
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["E402", "F401"]
+"chimerapy/__version__.py" = ["E402"]
+"docs/conf.py" = ["E402"]

--- a/test/benchmark/compression.py
+++ b/test/benchmark/compression.py
@@ -1,14 +1,13 @@
 import pickle
 import time
 
+import blosc
+import lz4.block
 import numpy as np
 
 import chimerapy as cp
 
 logger = cp._logger.getLogger("chimerapy")
-
-import lz4.block
-import blosc
 
 
 def lz4_com_op(payload):
@@ -50,7 +49,7 @@ def payload_compression_performance():
             c_payload = com_fun(payload)
 
             tac = time.perf_counter()
-            new_payload = dec_fun(c_payload)
+            new_payload = dec_fun(c_payload)  # noqa: F841
 
             toc = time.perf_counter()
             # assert isinstance(new_payload['img'], np.ndarray)

--- a/test/benchmark/networking.py
+++ b/test/benchmark/networking.py
@@ -1,5 +1,5 @@
-from typing import Dict
 import socket
+from typing import Dict
 
 import chimerapy as cp
 

--- a/test/benchmark/serialization.py
+++ b/test/benchmark/serialization.py
@@ -1,18 +1,16 @@
-import time
-import json
-
-import numpy as np
-
-import nujson
-import orjson
-import cloudpickle
 import pickle
+import time
+
+import cloudpickle
 import msgpack
 import msgpack_numpy as m
-
-m.patch()
+import nujson
+import numpy as np
+import orjson
 
 import chimerapy as cp
+
+m.patch()
 
 logger = cp._logger.getLogger("chimerapy")
 
@@ -92,7 +90,7 @@ def payload_serial_deserial_performance():
 
             tac = time.perf_counter()
             assert type(b_payload) == bytes, f"{name}, {b_payload}"
-            new_payload = des_fun(b_payload)
+            new_payload = des_fun(b_payload)  # noqa: F841
 
             toc = time.perf_counter()
             # assert isinstance(new_payload['img'], np.ndarray)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,18 +1,16 @@
-from typing import Dict, Any
-import time
 import logging
-import pathlib
 import os
+import pathlib
 import platform
-import socket
-import pickle
-import threading
 import queue
+import time
+from typing import Dict
 
 import docker
 import pytest
 
 import chimerapy as cp
+
 from .mock import DockeredWorker
 
 logger = cp._logger.getLogger("chimerapy")
@@ -25,7 +23,7 @@ TEST_DATA_DIR = TEST_DIR / "data"
 try:
     current_platform = os.environ["MANUAL_OS_SET"]
     running_on_github_actions = os.environ["RUNNING_ON_GA"]
-except:
+except:  # noqa: E722
     current_platform = platform.system()
     running_on_github_actions = "Native"
 

--- a/test/front_end_integration/test_routes.py
+++ b/test/front_end_integration/test_routes.py
@@ -5,9 +5,6 @@ import pytest
 import requests
 from pytest_lazyfixture import lazy_fixture
 
-# Interal Imports
-import chimerapy as cp
-
 
 @pytest.mark.parametrize(
     "config_manager",

--- a/test/front_end_integration/test_ws.py
+++ b/test/front_end_integration/test_ws.py
@@ -1,8 +1,8 @@
-from typing import Dict
 import time
+from typing import Dict
 
 import pytest
-from aiohttp import web
+
 import chimerapy as cp
 from chimerapy.networking.enums import MANAGER_MESSAGE
 from chimerapy.states import ManagerState
@@ -46,7 +46,7 @@ def test_node_updates(test_ws_client, manager, worker):
 
     # Create original containers
     simple_graph = cp.Graph()
-    new_node = GenNode(name=f"Gen1")
+    new_node = GenNode(name="Gen1")
     simple_graph.add_nodes_from([new_node])
     mapping = {worker.id: [new_node.id]}
 

--- a/test/mock/__init__.py
+++ b/test/mock/__init__.py
@@ -1,2 +1,2 @@
-from .dockered_worker import DockeredWorker
 from . import test_package
+from .dockered_worker import DockeredWorker

--- a/test/mock/dockered_worker.py
+++ b/test/mock/dockered_worker.py
@@ -1,10 +1,11 @@
 # Built-in Imports
-import threading
 import queue
+import threading
 import uuid
 
 # Third-party
 import docker
+
 import chimerapy as cp
 
 logger = cp._logger.getLogger("chimerapy-networking")

--- a/test/networking/test_client_server.py
+++ b/test/networking/test_client_server.py
@@ -1,23 +1,12 @@
-from typing import Dict
-import time
-import socket
-import logging
-import pathlib
-import os
-import platform
-import tempfile
-import uuid
 import enum
-from aiohttp import web
-import requests
-
-from concurrent.futures import wait, Future
+import os
+import pathlib
+import time
+from typing import Dict
 
 import pytest
-from pytest_lazyfixture import lazy_fixture
-import numpy as np
-
-import pdb
+import requests
+from aiohttp import web
 
 import chimerapy as cp
 

--- a/test/networking/test_code_delivery.py
+++ b/test/networking/test_code_delivery.py
@@ -1,16 +1,15 @@
-import sys
-import pathlib
 import os
-import pdb
+import pathlib
 
 import pytest
 from pytest_lazyfixture import lazy_fixture
-import chimerapy as cp
 
-cp.debug()
+import chimerapy as cp
 
 # Internal Imports
 from ..conftest import linux_run_only
+
+cp.debug()
 
 # Constant
 TEST_DIR = pathlib.Path(os.path.abspath(__file__)).parent.parent
@@ -65,4 +64,4 @@ def test_sending_package(manager, _worker, config_graph):
     )
 
     for node_id in config_graph.G.nodes():
-        assert manager.workers[_worker.id].nodes[node_id].init == True
+        assert manager.workers[_worker.id].nodes[node_id].init

--- a/test/networking/test_connectivity.py
+++ b/test/networking/test_connectivity.py
@@ -1,7 +1,7 @@
 # Built-in Imports
-import time
-import pathlib
 import os
+import pathlib
+import time
 
 # Third-party
 import pytest

--- a/test/networking/test_subscriber_publisher.py
+++ b/test/networking/test_subscriber_publisher.py
@@ -1,9 +1,10 @@
 # Built-in Imports
 import time
 
+import numpy as np
+
 # Third-party Imports
 import pytest
-import numpy as np
 from pytest_lazyfixture import lazy_fixture
 
 # Internal Imports

--- a/test/streams/__init__.py
+++ b/test/streams/__init__.py
@@ -1,1 +1,1 @@
-from .data_nodes import AudioNode, VideoNode, ImageNode, TabularNode
+from .data_nodes import AudioNode, ImageNode, TabularNode, VideoNode

--- a/test/streams/data_nodes.py
+++ b/test/streams/data_nodes.py
@@ -1,10 +1,11 @@
 # Build-in Imports
 import time
 
-# Third-party Imports
-import pyaudio
 import numpy as np
 import pandas as pd
+
+# Third-party Imports
+import pyaudio
 
 # Internal Imports
 import chimerapy as cp

--- a/test/streams/test_audio.py
+++ b/test/streams/test_audio.py
@@ -1,21 +1,21 @@
 # Built-in Imports
 import os
 import pathlib
-import logging
-import uuid
 import time
+import uuid
 
 # Third-party
 import numpy as np
-import pytest
 import pyaudio
+import pytest
 
 # Internal Imports
 import chimerapy as cp
 
+from .data_nodes import AudioNode
+
 logger = cp._logger.getLogger("chimerapy")
 
-from .data_nodes import AudioNode
 
 # Constants
 CWD = pathlib.Path(os.path.abspath(__file__)).parent.parent

--- a/test/streams/test_direct_av.py
+++ b/test/streams/test_direct_av.py
@@ -1,22 +1,23 @@
 # Built-in Imports
-import logging
-import pathlib
 import os
+import pathlib
 import time
-import pdb
+import wave
+
+import cv2
+import numpy as np
+import pyaudio
 
 # Third-party Import
 import pytest
-import wave
-import pyaudio
-import numpy as np
-import cv2
+
 import chimerapy as cp
+
+# Internal Testing imports
+from ..conftest import not_github_actions
 
 logger = cp._logger.getLogger("chimerapy")
 
-# Interal Testing imports
-from ..conftest import not_github_actions
 
 # Constants
 CWD = pathlib.Path(os.path.abspath(__file__)).parent.parent
@@ -89,7 +90,7 @@ def test_write_video():
         cap = cv2.VideoCapture(0)
         ret, frame = cap.read()
         assert isinstance(frame, np.ndarray)
-    except:
+    except:  # noqa: E722
         cap = RandomGenerator()
         ret, frame = cap.read()
 

--- a/test/streams/test_image.py
+++ b/test/streams/test_image.py
@@ -1,7 +1,6 @@
 # Built-in Imports
 import os
 import pathlib
-import logging
 import time
 import uuid
 
@@ -12,8 +11,9 @@ import pytest
 # Internal Imports
 import chimerapy as cp
 
-logger = cp._logger.getLogger("chimerapy")
 from .data_nodes import ImageNode
+
+logger = cp._logger.getLogger("chimerapy")
 
 # Constants
 CWD = pathlib.Path(os.path.abspath(__file__)).parent.parent

--- a/test/streams/test_tabular.py
+++ b/test/streams/test_tabular.py
@@ -1,19 +1,18 @@
 # Built-in Imports
 import os
 import pathlib
-import logging
-import uuid
 import time
+import uuid
 
 # Third-party
-import pandas as pd
-import numpy as np
 import pytest
+
 import chimerapy as cp
 
 # Internal Imports
-logger = cp._logger.getLogger("chimerapy")
 from .data_nodes import TabularNode
+
+logger = cp._logger.getLogger("chimerapy")
 
 # Constants
 CWD = pathlib.Path(os.path.abspath(__file__)).parent.parent

--- a/test/streams/test_transfer.py
+++ b/test/streams/test_transfer.py
@@ -1,9 +1,6 @@
 # Built-in Imports
-import os
-import time
-import logging
 import collections
-import pathlib
+import time
 
 # Third-party Imports
 import dill
@@ -13,16 +10,14 @@ from pytest_lazyfixture import lazy_fixture
 # Internal Imports
 import chimerapy as cp
 
+from ..conftest import linux_run_only
+from ..mock import DockeredWorker
+from ..utils import cleanup_and_recreate_dir
+from .data_nodes import AudioNode, ImageNode, TabularNode, VideoNode
+
 logger = cp._logger.getLogger("chimerapy")
 # cp.debug(["chimerapy-networking"])
 cp.debug()
-
-from .data_nodes import VideoNode, AudioNode, ImageNode, TabularNode
-from ..conftest import linux_run_only, linux_expected_only
-from ..mock import DockeredWorker
-from ..utils import cleanup_and_recreate_dir
-import shutil
-
 pytestmark = [pytest.mark.slow, pytest.mark.timeout(600)]
 
 # References:

--- a/test/streams/test_video.py
+++ b/test/streams/test_video.py
@@ -1,22 +1,20 @@
 # Built-in Imports
 import os
 import pathlib
-import platform
-import tempfile
-import logging
 import time
-import queue
 import uuid
 
 # Third-party
 import cv2
 import numpy as np
 import pytest
+
 import chimerapy as cp
 
 # Internal Imports
-logger = cp._logger.getLogger("chimerapy")
 from .data_nodes import VideoNode
+
+logger = cp._logger.getLogger("chimerapy")
 
 # cp.debug()
 

--- a/test/test_data_chunk.py
+++ b/test/test_data_chunk.py
@@ -1,10 +1,9 @@
 import json
 
-
+import numpy as np
 import pytest
 from pytest_lazyfixture import lazy_fixture
 
-import numpy as np
 import chimerapy as cp
 
 

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -1,8 +1,4 @@
-import logging
-import sys
-
 import chimerapy as cp
-import pytest
 
 from .conftest import linux_run_only
 

--- a/test/test_entrypoint.py
+++ b/test/test_entrypoint.py
@@ -1,16 +1,14 @@
 # Built-in Imports
-import logging
 import subprocess
 import time
-import sys
 
 # Third-party Imports
-import pytest
 import chimerapy as cp
+
+from .conftest import linux_run_only
 
 # Test Import
 from .mock import DockeredWorker
-from .conftest import linux_run_only
 
 logger = cp._logger.getLogger("chimerapy")
 cp.debug()

--- a/test/test_error_handling.py
+++ b/test/test_error_handling.py
@@ -1,12 +1,9 @@
 # Built-in Imports
-import logging
 import time
+
 import dill
-import pathlib
-import os
 
 # Third-party Imports
-import yaml
 import pytest
 
 import chimerapy as cp

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -30,7 +30,7 @@ def test_logger_publishing():
 
     def log_():
         time.sleep(1)  # Wait for the subscriber to connect
-        for l in logs:
+        for l in logs:  # noqa: E741
             logger.info(l)
 
     thread = threading.Thread(target=subscribe_and_read)

--- a/test/test_node_interactions.py
+++ b/test/test_node_interactions.py
@@ -1,7 +1,5 @@
-from typing import Dict, Any
 import time
-import logging
-import pdb
+from typing import Dict
 
 import numpy as np
 import pytest

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -1,8 +1,5 @@
-import logging
-
 import pytest
 from pytest_lazyfixture import lazy_fixture
-import numpy as np
 
 import chimerapy as cp
 

--- a/test/test_threaded_async.py
+++ b/test/test_threaded_async.py
@@ -1,13 +1,14 @@
 # Built-in Imports
-import time
 import asyncio
+import time
 
 # Third-party Imports
 import pytest
 
+import chimerapy as cp
+
 # ChimeraPy Imports
 from chimerapy.networking import AsyncLoopThread
-import chimerapy as cp
 
 logger = cp._logger.getLogger("chimerapy")
 cp.debug()
@@ -25,7 +26,7 @@ def test_callback_execution(thread):
     queue = asyncio.Queue()
 
     def put(queue):
-        logger.debug(f"put called")
+        logger.debug("put called")
         queue.put_nowait(1)
 
     thread.exec_noncoro(put, args=[queue])
@@ -37,7 +38,7 @@ def test_callback_execution_with_wait(thread):
     queue = asyncio.Queue()
 
     def put(queue):
-        logger.debug(f"put called")
+        logger.debug("put called")
         queue.put_nowait(1)
 
     finished = thread.exec_noncoro(put, args=[queue], waitable=True)

--- a/test/test_use_cases.py
+++ b/test/test_use_cases.py
@@ -1,15 +1,13 @@
-from typing import Dict, Any
-import time
-import logging
+import multiprocessing as mp
 import os
 import sys
-import multiprocessing as mp
+import time
+from typing import Dict
 
-from PIL import ImageGrab
 import cv2
 import numpy as np
-import imutils
 import pytest
+from PIL import ImageGrab
 from pytest_lazyfixture import lazy_fixture
 
 import chimerapy as cp

--- a/test/test_worker_node_interactions.py
+++ b/test/test_worker_node_interactions.py
@@ -1,22 +1,21 @@
-import time
 import logging
-import threading
 import multiprocessing as mp
-import queue
-import sys
 import os
 import pathlib
+import queue
+import threading
+import time
 from functools import partial
-import requests
 
-import pytest
 import dill
+import pytest
+import requests
+from pytest_lazyfixture import lazy_fixture
 
 import chimerapy as cp
 
-from .conftest import GenNode, ConsumeNode, linux_expected_only, linux_run_only
-from pytest_lazyfixture import lazy_fixture
-from .streams import AudioNode, VideoNode, ImageNode, TabularNode
+from .conftest import ConsumeNode, GenNode, linux_expected_only, linux_run_only
+from .streams import AudioNode, ImageNode, TabularNode, VideoNode
 
 logger = cp._logger.getLogger("chimerapy")
 cp.debug()
@@ -383,7 +382,7 @@ def test_manager_directing_worker_to_create_node(_manager, _worker):
 
     # Create original containers
     simple_graph = cp.Graph()
-    new_node = GenNode(name=f"Gen1")
+    new_node = GenNode(name="Gen1")
     simple_graph.add_nodes_from([new_node])
     mapping = {_worker.id: [new_node.id]}
 


### PR DESCRIPTION
This PR is a lot of maintainence change / cleanup for adding `ruff` as a pre-commit hook and all the fixes 

1. isort
2. removing unused imports
3. cleaning up some linting issues


Currently, ignoring `max-line-length` that is of 88 lines.